### PR TITLE
refactor build entry and cleanup script

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -20,7 +20,7 @@ async function copyStaticFiles() {
 
 // Build configuration
 const buildConfig = {
-    entryPoints: ["main.ts"],
+    entryPoints: ["src/main.ts"],
     bundle: true,
     external: ["obsidian", "electron", ...builtins],
     format: "cjs",

--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,0 @@
-import UltimaOrbPlugin from "./src/UltimaOrbPlugin";
-
-export default UltimaOrbPlugin;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:watch": "vitest --watch",
     "test:all": "node scripts/test-all.js",
     "type-check": "tsc --noEmit",
-    "clean": "rimraf main.js dist",
+    "clean": "node scripts/clean.mjs",
     "prebuild": "npm run clean",
     "predev": "npm run type-check",
     "version": "node version-bump.mjs && git add manifest.json versions.json"

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,14 @@
+import { rm } from "fs/promises";
+
+async function clean() {
+  await Promise.all([
+    rm("main.js", { force: true }),
+    rm("dist", { recursive: true, force: true }),
+  ]);
+}
+
+clean().catch(err => {
+  console.error("Failed to clean build artifacts:", err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- remove redundant root entry and target `src/main.ts` in esbuild
- replace `rimraf` clean step with Node-based `scripts/clean.mjs`

## Testing
- `npm run build` *(fails: module 'tslib' cannot be found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c57a8388832fb09ea9aef979f262