### PR TITLE
Add Notion AI assistant and collaboration tests

### DIFF
--- a/src/tests/NotionAIAssistantTool.test.ts
+++ b/src/tests/NotionAIAssistantTool.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { NotionAIAssistantTool } from "../tools/NotionAIAssistantTool";
+
+// สร้าง mock objects สำหรับ dependencies ที่จำเป็น
+const mockApp = { vault: {} } as any;
+const mockApiManager = {
+  execute: async () => ({ success: true, data: { key: "dummy" }, timestamp: new Date() }),
+} as any;
+const mockAI = {
+  execute: async () => ({ success: true, data: {}, timestamp: new Date() }),
+} as any;
+
+describe("NotionAIAssistantTool", () => {
+  const assistant = new NotionAIAssistantTool(mockApp, mockApiManager, mockAI);
+
+  it("should expose correct metadata", () => {
+    const metadata = assistant.getMetadata();
+    expect(metadata.id).toBe("notion-ai-assistant");
+    expect(metadata.name).toBe("Notion AI Assistant");
+    expect(metadata.category).toBe("AI");
+  });
+
+  it("should handle unknown actions safely", async () => {
+    const result = await assistant.execute({ action: "unknown" });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Unknown action");
+  });
+});

--- a/src/tests/NotionAnalysisTest.ts
+++ b/src/tests/NotionAnalysisTest.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NotionAnalysisTool } from "../tools/NotionAnalysisTool";
-import { AIOrchestrationTool } from "../tools/AIOrchestrationTool";
+// ใช้ mock สำหรับ AIOrchestrationTool เพื่อหลีกเลี่ยงการเรียก network จริง
+import type { AIOrchestrationTool } from "../tools/AIOrchestrationTool";
 import { App } from "obsidian";
 
 // Mock App
@@ -14,10 +15,25 @@ const mockApp = {
 describe("NotionAnalysisTool", () => {
   let notionAnalysis: NotionAnalysisTool;
   let aiOrchestration: AIOrchestrationTool;
+  const originalFetch = global.fetch;
 
-  beforeEach(async () => {
-    aiOrchestration = new AIOrchestrationTool(mockApp);
+  beforeEach(() => {
+    // mock fetch ให้คืนข้อมูลจำลองและไม่เรียก external APIs
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ results: [] }),
+    })) as any;
+
+    // mock AIOrchestrationTool ด้วย object ที่มี method execute เท่านั้น
+    aiOrchestration = {
+      execute: async () => ({ success: true, data: {}, timestamp: new Date() }),
+    } as unknown as AIOrchestrationTool;
+
     notionAnalysis = new NotionAnalysisTool(mockApp, aiOrchestration);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   describe("Tool Metadata", () => {

--- a/src/tests/integration/ToolsCollaboration.test.ts
+++ b/src/tests/integration/ToolsCollaboration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { APIManagerTool } from "../../tools/APIManagerTool";
+import { NotionAIAssistantTool } from "../../tools/NotionAIAssistantTool";
+
+// mock Obsidian App สำหรับการจัดการไฟล์
+const mockApp = {
+  vault: {
+    getAbstractFileByPath: (_: string) => null,
+    read: async () => "{}",
+    modify: async () => {},
+    create: async () => ({}) as any,
+  },
+} as any;
+
+describe("Tools Collaboration", () => {
+  let apiManager: APIManagerTool;
+  let assistant: NotionAIAssistantTool;
+  let originalFetch: typeof fetch;
+
+  beforeEach(async () => {
+    apiManager = new APIManagerTool(mockApp);
+    await apiManager.execute({
+      action: "add_key",
+      provider: "notion",
+      keyName: "test",
+      apiKey: "secret",
+    });
+
+    const mockAI = {
+      execute: async () => ({ success: true, data: {}, timestamp: new Date() }),
+    } as any;
+
+    assistant = new NotionAIAssistantTool(mockApp, apiManager, mockAI);
+
+    originalFetch = global.fetch;
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        results: [
+          {
+            properties: {
+              title: { type: "title" },
+            },
+          },
+        ],
+      }),
+    })) as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should analyze structure using API key from APIManagerTool", async () => {
+    const result = await assistant.execute({ action: "analyze_structure" });
+    expect(result.success).toBe(true);
+    expect(result.data.totalDatabases).toBe(1);
+    expect((global.fetch as any)).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- mock network dependencies in NotionAnalysisTool tests for safer, offline execution
- add unit tests for NotionAIAssistantTool metadata and error handling
- add integration test verifying APIManagerTool and NotionAIAssistantTool collaboration

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:coverage` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d647f5c0832fbafe6a706511b389