### PR TITLE
docs: add API, user, and developer guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ Ultima-Orb/
 4. Run tests and security checks
 5. Submit a pull request
 
+## 📚 Documentation
+
+- [API Reference](./docs/API.md)
+- [User Guide](./docs/USER_GUIDE.md)
+- [Developer Guide](./docs/DEVELOPER_GUIDE.md)
+
 ## 📄 License
 
 MIT License - see LICENSE file for details

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,97 @@
+# 📚 API Reference
+
+## 🔧 Installation
+
+```bash
+npm install
+```
+
+> **Security:** เก็บ API keys ไว้ใน environment variables หรือผ่าน API Manager เท่านั้น ดูเพิ่มเติมใน [SECURITY.md](../SECURITY.md)
+
+## 🛠️ Tools
+
+### APIManagerTool
+```ts
+import { APIManagerTool } from "../src/tools/APIManagerTool";
+const tool = new APIManagerTool(app);
+await tool.execute({
+  action: "add_key",
+  provider: "openai",
+  keyName: "default",
+  apiKey: process.env.OPENAI_API_KEY || ""
+});
+```
+
+### NotionAIAssistantTool
+```ts
+const tool = new NotionAIAssistantTool(app, apiManager, ai);
+await tool.execute({
+  action: "analyze_structure",
+  databaseId: "your-db-id"
+});
+```
+
+### NotionDataAutomationTool
+```ts
+const tool = new NotionDataAutomationTool(app, apiManager);
+await tool.execute({
+  action: "create_automation_rule",
+  name: "Auto Tag",
+  trigger: "on_create",
+  actions: [{ type: "add_tag", target: "status", value: "new" }]
+});
+```
+
+### AirtableIntegrationTool
+```ts
+const tool = new AirtableIntegrationTool(app, apiManager);
+await tool.execute({
+  action: "list_bases"
+});
+```
+
+### FileImportTool
+```ts
+const tool = new FileImportTool(app, apiManager);
+await tool.execute({
+  action: "import_url",
+  url: "https://example.com",
+  targetFolder: "AI References"
+});
+```
+
+### ObsidianBasesTool
+```ts
+const tool = new ObsidianBasesTool(app);
+await tool.execute({
+  action: "create_base",
+  baseName: "Projects",
+  properties: { title: { type: "text" } }
+});
+```
+
+### WebhookIntegrationTool
+```ts
+const tool = new WebhookIntegrationTool(app);
+await tool.execute({
+  action: "registerWebhook",
+  integration: "notion",
+  webhookUrl: "https://example.com/webhook",
+  event: "update"
+});
+```
+
+### NotionAnalysisTool
+```ts
+const tool = new NotionAnalysisTool(app, ai);
+await tool.execute({
+  action: "fetchAllDatabases"
+});
+```
+
+### NotionDataAnalyzer
+```ts
+import { NotionDataAnalyzer } from "../src/analysis/NotionDataAnalyzer";
+const analyzer = new NotionDataAnalyzer();
+const report = await analyzer.analyze({ databaseId: "your-db-id" });
+```

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,30 @@
+# 🛠️ Developer Guide
+
+## Prerequisites
+- Node.js 18+
+- npm
+- Obsidian for plugin testing
+
+## Setup
+```bash
+git clone <repo>
+cd ultima-orb
+npm install
+```
+
+## Development
+```bash
+npm run dev   # watch mode
+npm run build # production build
+```
+
+## Testing
+```bash
+npm test
+```
+> หากไม่มี `vitest` ให้รัน `npm install` ก่อน
+
+## Security
+- ไม่ hardcode API keys
+- ใช้ environment variables
+- อ่านเพิ่มเติมที่ [SECURITY.md](../SECURITY.md)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -10,8 +10,9 @@
 6. [การเชื่อมต่อกับบริการภายนอก (External Integrations)](#การเชื่อมต่อกับบริการภายนอก-external-integrations)
 7. [การจัดการความรู้ (Knowledge Management)](#การจัดการความรู้-knowledge-management)
 8. [การตั้งค่าขั้นสูง (Advanced Settings)](#การตั้งค่าขั้นสูง-advanced-settings)
-9. [การแก้ไขปัญหา (Troubleshooting)](#การแก้ไขปัญหา-troubleshooting)
-10. [คำถามที่พบบ่อย (FAQ)](#คำถามที่พบบ่อย-faq)
+9. [ตัวอย่างการใช้งาน Tools (Tool Usage Examples)](#ตัวอย่างการใช้งาน-tools-tool-usage-examples)
+10. [การแก้ไขปัญหา (Troubleshooting)](#การแก้ไขปัญหา-troubleshooting)
+11. [คำถามที่พบบ่อย (FAQ)](#คำถามที่พบบ่อย-faq)
 
 ---
 
@@ -40,8 +41,9 @@
 
 1. **ดาวน์โหลด** ไฟล์ `.zip` จาก GitHub releases
 2. **แตกไฟล์** ไปยัง `.obsidian/plugins/ultima-orb/`
-3. **รีสตาร์ท** Obsidian
-4. **เปิดใช้งาน** plugin
+3. **รัน** `npm install` **ในโฟลเดอร์ plugin** (ถ้าต้องการ build)
+4. **รีสตาร์ท** Obsidian
+5. **เปิดใช้งาน** plugin
 
 ---
 
@@ -356,6 +358,81 @@ Max Tokens: 1000
 - **Context Window**: ขนาดหน้าต่างบริบท
 - **Context Strategy**: กลยุทธ์การจัดการบริบท
 - **Memory Management**: การจัดการหน่วยความจำ
+
+---
+
+## 🛠️ ตัวอย่างการใช้งาน Tools (Tool Usage Examples)
+
+### APIManagerTool
+```ts
+const tool = new APIManagerTool(app);
+await tool.execute({
+  action: 'add_key',
+  provider: 'openai',
+  keyName: 'default',
+  apiKey: process.env.OPENAI_API_KEY || ''
+});
+```
+
+### NotionAIAssistantTool
+```ts
+const tool = new NotionAIAssistantTool(app, apiManager, ai);
+await tool.execute({ action: 'analyze_structure', databaseId: 'your-db-id' });
+```
+
+### NotionDataAutomationTool
+```ts
+await new NotionDataAutomationTool(app, apiManager).execute({
+  action: 'create_automation_rule',
+  name: 'Auto Tag',
+  trigger: 'on_create',
+  actions: [{ type: 'add_tag', target: 'status', value: 'new' }]
+});
+```
+
+### AirtableIntegrationTool
+```ts
+await new AirtableIntegrationTool(app, apiManager).execute({ action: 'list_bases' });
+```
+
+### FileImportTool
+```ts
+await new FileImportTool(app, apiManager).execute({
+  action: 'import_url',
+  url: 'https://example.com',
+  targetFolder: 'AI References'
+});
+```
+
+### ObsidianBasesTool
+```ts
+await new ObsidianBasesTool(app).execute({
+  action: 'create_base',
+  baseName: 'Projects',
+  properties: { title: { type: 'text' } }
+});
+```
+
+### WebhookIntegrationTool
+```ts
+await new WebhookIntegrationTool(app).execute({
+  action: 'registerWebhook',
+  integration: 'notion',
+  webhookUrl: 'https://example.com/webhook',
+  event: 'update'
+});
+```
+
+### NotionAnalysisTool
+```ts
+await new NotionAnalysisTool(app, ai).execute({ action: 'fetchAllDatabases' });
+```
+
+### NotionDataAnalyzer
+```ts
+const analyzer = new NotionDataAnalyzer();
+const report = await analyzer.analyze({ databaseId: 'your-db-id' });
+```
 
 ---
 

--- a/src/test-notion-analysis.js
+++ b/src/test-notion-analysis.js
@@ -127,8 +127,7 @@ async function testNotionConnection() {
     const response = await fetch("https://api.notion.com/v1/search", {
       method: "POST",
       headers: {
-        Authorization:
-          "Bearer patSAFehqyaDt50Lt.9323a998b3b0babe891fb0c0af5bbbc76e8ec4d0da33ef8b212745c8c3efc0bf",
+        Authorization: `Bearer ${process.env.NOTION_API_KEY || ""}`,
         "Notion-Version": "2022-06-28",
         "Content-Type": "application/json",
       },

--- a/src/tests/NotionAnalysisDemo.ts
+++ b/src/tests/NotionAnalysisDemo.ts
@@ -125,7 +125,7 @@ export async function testNotionConnection() {
       method: "POST",
       headers: {
         Authorization:
-          "Bearer patSAFehqyaDt50Lt.9323a998b3b0babe891fb0c0af5bbbc76e8ec4d0da33ef8b212745c8c3efc0bf",
+          `Bearer ${process.env.NOTION_API_KEY || ""}`,
         "Notion-Version": "2022-06-28",
         "Content-Type": "application/json",
       },

--- a/src/tools/NotionAnalysisTool.ts
+++ b/src/tools/NotionAnalysisTool.ts
@@ -24,8 +24,7 @@ export class NotionAnalysisTool extends ToolBase {
     });
     this.app = app;
     this.aiOrchestration = aiOrchestration;
-    this.notionApiKey =
-      "patSAFehqyaDt50Lt.9323a998b3b0babe891fb0c0af5bbbc76e8ec4d0da33ef8b212745c8c3efc0bf";
+    this.notionApiKey = process.env.NOTION_API_KEY || "";
   }
 
   /**

--- a/src/tools/WebhookIntegrationTool.ts
+++ b/src/tools/WebhookIntegrationTool.ts
@@ -34,8 +34,7 @@ export class WebhookIntegrationTool extends ToolBase {
     this.integrations.set("notion", {
       name: "Notion",
       type: "database",
-      apiKey:
-        "patSAFehqyaDt50Lt.9323a998b3b0babe891fb0c0af5bbbc76e8ec4d0da33ef8b212745c8c3efc0bf",
+      apiKey: process.env.NOTION_API_KEY || "",
       webhookUrl: "",
       isActive: true,
       config: {


### PR DESCRIPTION
## Summary
- add API reference, user guide examples, and developer setup docs
- document installation steps and link guides from README
- remove hardcoded Notion API keys

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d64d6734832f91aa408f6d585671