### PR TITLE
chore: enforce single quote usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,8 +19,8 @@ module.exports = {
     'no-unused-vars': 'off',
     
     // 🔥 Quotes ต้องเป็น single
-    'quotes': ['error', 'double'],
-    '@typescript-eslint/quotes': ['error', 'double'],
+    'quotes': ['error', 'single'],
+    '@typescript-eslint/quotes': ['error', 'single'],
     
     // 🔥 Semicolons ต้องมี
     'semi': ['error', 'always'],


### PR DESCRIPTION
## Summary
- enforce single quotes in ESLint configuration

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@codemirror%2fstate)*
- `npm run lint -- --config .eslintrc.js --fix` *(fails: "root" key is not supported in flat config system)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f4a79350832f843d187527381315