### PR TITLE
feat(logger): add log levels

### DIFF
--- a/src/services/Logger.ts
+++ b/src/services/Logger.ts
@@ -1,24 +1,55 @@
 /**
  * 📝 Logger Service
- * Service สำหรับ logging ที่เรียบง่าย
+ * Service สำหรับ logging ที่ปรับระดับความสำคัญได้
  */
 
+/** ระดับของ log ที่รองรับ */
+export enum LogLevel {
+  ERROR = 0,
+  WARN = 1,
+  INFO = 2,
+  DEBUG = 3,
+}
+
 export class Logger {
-  private prefix = "[Ultima-Orb]";
+  private prefix: string;
+  private level: LogLevel;
+
+  constructor(prefix = '[Ultima-Orb]', level: LogLevel = LogLevel.INFO) {
+    this.prefix = prefix;
+    this.level = level;
+  }
+
+  /** เปลี่ยนระดับของ log ขณะรันไทม์ */
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    return level <= this.level;
+  }
 
   info<T extends unknown[]>(message: string, ...args: T): void {
-    console.info(`${this.prefix} [INFO] ${message}`, ...args);
+    if (this.shouldLog(LogLevel.INFO)) {
+      console.info(`${this.prefix} [INFO] ${message}`, ...args);
+    }
   }
 
   warn<T extends unknown[]>(message: string, ...args: T): void {
-    console.warn(`${this.prefix} [WARN] ${message}`, ...args);
+    if (this.shouldLog(LogLevel.WARN)) {
+      console.warn(`${this.prefix} [WARN] ${message}`, ...args);
+    }
   }
 
   error(message: string, error?: Error): void {
-    console.error(`${this.prefix} [ERROR] ${message}`, error);
+    if (this.shouldLog(LogLevel.ERROR)) {
+      console.error(`${this.prefix} [ERROR] ${message}`, error);
+    }
   }
 
   debug<T extends unknown[]>(message: string, ...args: T): void {
-    console.debug(`${this.prefix} [DEBUG] ${message}`, ...args);
+    if (this.shouldLog(LogLevel.DEBUG)) {
+      console.debug(`${this.prefix} [DEBUG] ${message}`, ...args);
+    }
   }
 }

--- a/test/unit/services/Logger.test.ts
+++ b/test/unit/services/Logger.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Logger, LogLevel } from '../../../src/services/Logger';
+
+describe('Logger', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    logger = new Logger('[Test]', LogLevel.INFO);
+    vi.restoreAllMocks();
+  });
+
+  it('logs info when level allows', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    logger.info('hello');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('does not log debug when level is info', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    logger.debug('debug');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('logs debug after level is changed', () => {
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    logger.setLevel(LogLevel.DEBUG);
+    logger.debug('debug');
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- support configurable log levels in Logger service
- add unit tests verifying log output suppression and enablement by level

## Testing
- `npm install` *(fails: 403 Forbidden fetching packages)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f3907ce4832fbf41809cf732995a